### PR TITLE
Fix an error in the gemspec

### DIFF
--- a/lib/screwcap/task.rb
+++ b/lib/screwcap/task.rb
@@ -216,6 +216,16 @@ class Task < Screwcap::Base
   def method_missing(m, *args) # :nodoc
     if m.to_s[0..1] == "__" or [:run].include?(m) or m.to_s.reverse[0..0] == "="
       super(m, args.first) 
+    elsif m == :to_ary
+      # In Ruby 1.9, Array#flatten calls #to_ary on each of the
+      # array's children and only if there is a NoMethodError raised
+      # does it assume the object is not an array. Compare this to
+      # 1.8.7 where Array#flatten used #respond_to? to determine
+      # if the object responded to #to_ary before calling it.
+      #
+      # Therefore we need to raise this error if someone calls #to_ary
+      # on us
+      raise NoMethodError
     else
       self.__commands << {:command => m, :type => :unknown, :from => self.__name}
     end

--- a/screwcap.gemspec
+++ b/screwcap.gemspec
@@ -13,9 +13,9 @@ Gem::Specification.new do |s|
   s.homepage    = "http://github.com/gammons/screwcap"
   s.summary     = "Screwcap is a wrapper of Net::SSH and allows for easy configuration, organization, and management of running tasks on remote servers."
  
-  s.add_dependency(['net-ssh','>=2.0.23'])
-  s.add_dependency(['net-ssh-gateway','>=1.0.1'])
-  s.add_dependency(['net-scp','>=1.0.4'])
+  s.add_dependency('net-ssh','>=2.0.23')
+  s.add_dependency('net-ssh-gateway','>=1.0.1')
+  s.add_dependency('net-scp','>=1.0.4')
   s.rubyforge_project = 'screwcap'
  
   s.files        = Dir.glob("{bin,lib}/**/*") + %w(README.rdoc screwcap.gemspec)


### PR DESCRIPTION
I kept getting an error:

```
Could not find gem '["net-scp", ">=1.0.4"]', required by 'screwcap', in any of the sources
```

When I tried to do a bundle update with screwcap in my Gemfile, and I found that dependencies were declared like:

```
s.add_dependency(['net-scp','>=1.0.4'])
```

But reading I've done suggests that you shouldn't put the dependency arguments in an array, so in my latest commit I've removed them:

```
s.add_dependency('net-scp','>=1.0.4')
```

And now when I do a bundle update, everything works fine.
